### PR TITLE
Improvements to portability and flexibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ ifndef EXPIRE
 EXPIRE := "1m"
 endif
 
+ifndef ALGORITHM_PRIM
+ALGORITHM_PRIM := "rsa4096"
+endif
+ifndef ALGORITHM_SUB
+ALGORITHM_SUB := "rsa4096"
+endif
+
 KEYID = $(shell gpg -k --with-colons $(UID) | grep "^fpr" | head -n1 | cut -d: -f10)
 KGRIP = $(shell gpg -K --with-colons $(UID) | sed -n 3p | cut -d: -f10)
 
@@ -42,14 +49,14 @@ import: backupdir purge-secrets
 # Create a key from scratch
 new-key:
 	@./bin/green "Generating a new key"
-	gpg --quick-gen-key $(UID) rsa4096 cert never
+	gpg --quick-gen-key $(UID) $(ALGORITHM_PRIM) cert never
 
 # Add new encryption/signing/authentication subkeys to the key
 add-subkeys:
 	@./bin/green "Generating subkeys for encr, sign and auth"
-	gpg --quick-add-key $(KEYID) rsa4096 encr $(EXPIRE)
-	gpg --quick-add-key $(KEYID) rsa4096 sign $(EXPIRE)
-	gpg --quick-add-key $(KEYID) rsa4096 auth $(EXPIRE)
+	gpg --quick-add-key $(KEYID) $(ALGORITHM_SUB) encr $(EXPIRE)
+	gpg --quick-add-key $(KEYID) $(ALGORITHM_SUB) sign $(EXPIRE)
+	gpg --quick-add-key $(KEYID) $(ALGORITHM_SUB) auth $(EXPIRE)
 
 # Revoke all the subkeys of the key (reason is "key superseded")
 rev-subkeys:

--- a/README.md
+++ b/README.md
@@ -47,9 +47,64 @@ Edit config.mk to suit your needs.
   I use a removable usb stick.
 * `EXPIRE` is how long you want the subkeys to be valid.
 
-Once you are done, you can go ahead and type
+### Full worklow
+Once the configuration has been done, run: 
 
     make new
 
-TODO: give info about what this does
+This will create the new key set including:
+
+- A primary key with Certify attribute
+- A subkey with Authentication attribute
+- A subkey with Encryption attribute
+- A subkey with Signature attribute
+
+The primary key is backed up in the backup directory set in the configuation
+file.
+
+Once the keys have been generated, the primary key may be removed from the
+keyring (recommended) by running:
+
+    make strip-master
+
+The primary secret key can be imported later using 
+
+    make import
+
+After removing the primary key, the subkeys can be moved to a keycard using
+
+    make keystocard
+
+The public key is now ready to be published with 
+
+    make publish
+
+When time comes, the subkeys can be renewed using the target
+
+    make renew
+
+This command will reimport the backed up secret key, revoke the current subkeys
+and generate three new subkeys. The workflow continues with strip-master etc.
+
+In case of theft, or loss of the keys they can be manually revoked using
+
+    make rev-subkeys
+
+In the same way, the master key can be revoked using 
+
+    make revoke
+
+Do not forget to publish your keys after every key creations, or revokations.
+
+#### Todo
+
+Document : 
+
+- export
+- new-key
+- backupdir
+- purge-secrets
+
+
+
 

--- a/bin/revoke-all-subkeys
+++ b/bin/revoke-all-subkeys
@@ -6,17 +6,16 @@
 [ -z $1 ] && exit
 
 revoke_subkey(){
-expect -c "
-spawn gpg --edit-key $1
-send \"key $2\\r\"
-send \"revkey\\r\"
-send \"y\\r\"
-send \"2\\r\"
-send \"\\r\"
-send \"y\\r\"
-send \"save\\r\"
-interact
-"
+    echo "Revoking $1 $2"
+    gpg --batch --command-fd 0 --edit-key $1 << EOI
+key $2
+revkey
+y
+2
+
+y
+save
+EOI
 }
 
 keyid=$1

--- a/bin/transfer-subkeys-to-card
+++ b/bin/transfer-subkeys-to-card
@@ -23,15 +23,13 @@ keyusage(){
 }
 
 keytocard(){
-expect -c "
-spawn gpg --edit-key $1
-send \"key $2\\r\"
-send \"keytocard\\r\"
-send \"$3\r\"
-send \"y\\r\"
-send \"save\\r\"
-interact
-"
+    gpg --batch --command-fd 0 --edit-key $1 << EOI
+key $2
+keytocard
+$3
+y
+save
+EOI
 }
 
 # Get the number of subkeys

--- a/config.mk.example
+++ b/config.mk.example
@@ -7,3 +7,9 @@ endif
 ifndef EXPIRE
 EXPIRE := "1m"
 endif
+ifndef ALGORITHM_PRIM
+ALGORITHM_PRIM := "rsa4096"
+endif
+ifndef ALGORITHM_SUB
+ALGORITHM_SUB := "rsa4096"
+endif


### PR DESCRIPTION
Adds new options to change the key algorithms for master and subkeys independently. 
Removes the use of the expect command for a more portable stdin redirection. 